### PR TITLE
fix: typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Usage
 import { GanacheProvider } from "@ethers-ext/provider-ganache";
 
 // Create a new in-memory GanacheProvider
-provider = new GanacheProvider();
+const provider = new GanacheProvider();
 
 
 ///////////////////


### PR DESCRIPTION
- add a missing const to README example